### PR TITLE
Add mb.imageblacklist and its subcommands

### DIFF
--- a/src/help.py
+++ b/src/help.py
@@ -21,7 +21,8 @@ SHOWOFF_COMMANDS = [
     "poll",
     "remindme",
     "whatis",
-    "youtube"
+    "youtube",
+    "imageblacklist",
 ]
 MINOR_SHOWOFF_COMMANDS = [
     "bully",

--- a/src/picturecommands.py
+++ b/src/picturecommands.py
@@ -824,7 +824,7 @@ class ReactionImages(discord.ext.commands.Cog):
             await ctx.send("\n".join(url_group))
             await asyncio.sleep(0.5)
 
-    @commands.group()
+    @commands.group(aliases=["imgbl", "imgblacklist", "imagebl"])
     async def imageblacklist(self, ctx):
         """Gets your blacklisted images"""
         if ctx.invoked_subcommand is not None:

--- a/src/picturecommands.py
+++ b/src/picturecommands.py
@@ -824,9 +824,26 @@ class ReactionImages(discord.ext.commands.Cog):
             await ctx.send("\n".join(url_group))
             await asyncio.sleep(0.5)
 
-    @commands.command()
-    async def nolike(self, ctx, cmd_and_key: str):
-        """Don't like an image? mb.nolike imagecommand/image01.png"""
+    @commands.group()
+    async def imageblacklist(self, ctx):
+        """Gets your blacklisted images"""
+        if ctx.invoked_subcommand is not None:
+            return
+        cmd_image_pairs = get_user_blacklist(
+            self.bot.db_connection, ctx.author.id)
+        if not cmd_image_pairs:
+            await ctx.send("Looks like you haven't blacklisted any images!")
+            return
+        cmd_image_pairs_text = ", ".join([
+            f"{cmd}/{image_key}" for cmd, image_key in cmd_image_pairs])
+        await ctx.send(f"Your blacklisted images: {cmd_image_pairs_text}")
+
+    @imageblacklist.command(aliases=["add"])
+    async def add_to_blacklist(self, ctx, cmd_and_key: str):
+        """
+        Don't like an image?
+        mb.imageblacklist add imagecommand/image01.png
+        """
         uid = ctx.author.id
         try:
             cmd, image_key = cmd_and_key.split("/")
@@ -844,9 +861,12 @@ class ReactionImages(discord.ext.commands.Cog):
         add_blacklist_association(self.bot.db_connection, cmd, image_key, uid)
         await ctx.send("Done!")
 
-    @commands.command()
-    async def relike(self, ctx, cmd_and_key: str):
-        """Undo a mb.nolike command"""
+    @imageblacklist.command(aliases=["remove"])
+    async def remove_from_blacklist(self, ctx, cmd_and_key: str):
+        """
+        Undo a mb.imageblacklist add command
+        mb.imageblacklist remove imagecommand/image01.png
+        """
         uid = ctx.author.id
         try:
             cmd, image_key = cmd_and_key.split("/")
@@ -865,17 +885,13 @@ class ReactionImages(discord.ext.commands.Cog):
             self.bot.db_connection, cmd, image_key, uid)
         await ctx.send("Sure!")
 
-    @commands.command()
-    async def myblacklist(self, ctx):
-        """Gets your "nolike" blacklist"""
-        cmd_image_pairs = get_user_blacklist(
-            self.bot.db_connection, ctx.author.id)
-        if not cmd_image_pairs:
-            await ctx.send("Looks like you haven't blacklisted any images!")
-            return
-        cmd_image_pairs_text = ", ".join([
-            f"{cmd}/{image_key}" for cmd, image_key in cmd_image_pairs])
-        await ctx.send(f"Your blacklisted images: {cmd_image_pairs_text}")
+    @commands.command(hidden=True)
+    async def nolike(self, ctx, cmd_and_key: str):
+        await self.add_to_blacklist(ctx, cmd_and_key)
+
+    @commands.command(hidden=True)
+    async def relike(self, ctx, cmd_and_key: str):
+        await self.remove_from_blacklist(ctx, cmd_and_key)
 
 
 def setup(bot):

--- a/src/picturecommands.py
+++ b/src/picturecommands.py
@@ -826,7 +826,12 @@ class ReactionImages(discord.ext.commands.Cog):
 
     @commands.group(aliases=["imgbl", "imgblacklist", "imagebl"])
     async def imageblacklist(self, ctx):
-        """Gets your blacklisted images"""
+        """
+        See, add to, or remove from your blacklisted images!
+        mb.imageblacklist
+        mb.imageblacklist add imagecommand/image01.png
+        mb.imageblacklist remove imagecommand/image01.png
+        """
         if ctx.invoked_subcommand is not None:
             return
         cmd_image_pairs = get_user_blacklist(
@@ -838,10 +843,10 @@ class ReactionImages(discord.ext.commands.Cog):
             f"{cmd}/{image_key}" for cmd, image_key in cmd_image_pairs])
         await ctx.send(f"Your blacklisted images: {cmd_image_pairs_text}")
 
-    @imageblacklist.command(aliases=["add"])
-    async def add_to_blacklist(self, ctx, cmd_and_key: str):
+    @imageblacklist.command()
+    async def add(self, ctx, cmd_and_key: str):
         """
-        Don't like an image?
+        Add an image to a list of images that you don't want to see
         mb.imageblacklist add imagecommand/image01.png
         """
         uid = ctx.author.id
@@ -861,8 +866,8 @@ class ReactionImages(discord.ext.commands.Cog):
         add_blacklist_association(self.bot.db_connection, cmd, image_key, uid)
         await ctx.send("Done!")
 
-    @imageblacklist.command(aliases=["remove"])
-    async def remove_from_blacklist(self, ctx, cmd_and_key: str):
+    @imageblacklist.command()
+    async def remove(self, ctx, cmd_and_key: str):
         """
         Undo a mb.imageblacklist add command
         mb.imageblacklist remove imagecommand/image01.png


### PR DESCRIPTION
Add mb.imageblacklist, mb.imageblacklist add, mb.imageblacklist remove, and add them to the mb.help command.
Because of how discord.py works, this required making a function called `add` and another called `remove`. Gross.
Closes #217 