### PR TITLE
Remove references to old 'naobot' name

### DIFF
--- a/src/base.py
+++ b/src/base.py
@@ -30,7 +30,6 @@ class Base(discord.ext.commands.Cog):
         """
         prefix_combinations = itertools.product('mMnN', 'bB', '.!', [' ', ''])
         prefixes = [''.join(r) for r in prefix_combinations]
-        prefixes += ["nao.", "Nao."]
         self.bot.command_prefix = commands.when_mentioned_or(*prefixes)
         cursor = self.bot.db_connection.cursor(cursor_factory=RealDictCursor)
         cursor.execute(


### PR DESCRIPTION
> queen tired — Today at 2:02 PM
> are there servers where makubot is known as naobot or are those prefixes just leftover from when you had named it that?
> Makusu2 — Today at 2:03 PM
> Not as far as I'm aware. I wanna get rid of the nao stuff.